### PR TITLE
cli+client: wire -X, -d, -H flags into request construction

### DIFF
--- a/cli/root.go
+++ b/cli/root.go
@@ -178,12 +178,16 @@ Run 'lnget schema --all' for full machine-readable CLI introspection.`,
 		"Content-Type header for request body")
 
 	// Agent-friendly long-form aliases for wget/curl-style flags.
-	// These are hidden to avoid cluttering --help but appear in
-	// schema introspection and work identically to the short forms.
+	// Hidden from --help to avoid clutter but visible in schema
+	// introspection. Only one of each pair may be used per
+	// invocation (e.g. --method OR -X, not both).
 	cmd.Flags().String("method", "",
 		"HTTP method (alias for -X/--request)")
 	cmd.Flags().String("body", "",
 		"Request body data (alias for -d/--data)")
+	_ = cmd.Flags().MarkHidden("method")
+	_ = cmd.Flags().MarkHidden("body")
+
 	cmd.Flags().BoolVarP(&flags.followRedirects, "location", "L", true,
 		"Follow redirects")
 	cmd.Flags().IntVar(&flags.maxRedirects, "max-redirects", 10,
@@ -338,15 +342,22 @@ func buildRequest(ctx context.Context, url string) (*http.Request, error) {
 		req.Header.Set("Content-Type", flags.contentType)
 	}
 
-	// Apply custom headers from -H/--header flags.
+	// Apply custom headers from -H/--header flags. Each header
+	// must be in "Name: Value" format; malformed entries are
+	// rejected to prevent silent misconfiguration.
 	for _, h := range flags.headers {
 		parts := strings.SplitN(h, ":", 2)
-		if len(parts) == 2 {
-			req.Header.Set(
-				strings.TrimSpace(parts[0]),
-				strings.TrimSpace(parts[1]),
+		if len(parts) != 2 || strings.TrimSpace(parts[0]) == "" {
+			return nil, fmt.Errorf(
+				"invalid header format %q "+
+					"(expected Name: Value)", h,
 			)
 		}
+
+		req.Header.Set(
+			strings.TrimSpace(parts[0]),
+			strings.TrimSpace(parts[1]),
+		)
 	}
 
 	return req, nil
@@ -354,8 +365,23 @@ func buildRequest(ctx context.Context, url string) (*http.Request, error) {
 
 // applyFlagAliases copies values from long-form agent-friendly aliases
 // (--method, --body) into the canonical flag fields when the alias was
-// explicitly provided by the user.
-func applyFlagAliases(cmd *cobra.Command) {
+// explicitly provided by the user. It returns an error if both an
+// alias and its canonical counterpart are set simultaneously.
+func applyFlagAliases(cmd *cobra.Command) error {
+	// Reject conflicting flag pairs. Each alias is mutually
+	// exclusive with its canonical form.
+	if cmd.Flags().Changed("method") && cmd.Flags().Changed("request") {
+		return ErrInvalidArgsf(
+			"--method and -X/--request are aliases; use only one",
+		)
+	}
+
+	if cmd.Flags().Changed("body") && cmd.Flags().Changed("data") {
+		return ErrInvalidArgsf(
+			"--body and -d/--data are aliases; use only one",
+		)
+	}
+
 	if cmd.Flags().Changed("method") {
 		v, _ := cmd.Flags().GetString("method")
 		flags.method = v
@@ -365,11 +391,17 @@ func applyFlagAliases(cmd *cobra.Command) {
 		v, _ := cmd.Flags().GetString("body")
 		flags.data = v
 	}
+
+	return nil
 }
 
 // resolveURL extracts the target URL from --params JSON or positional
 // args. If --params is set, its fields are applied to the global flags
 // struct as side effects.
+//
+// Flag precedence (highest wins):
+//
+//	--params JSON > --method/--body (aliases) > -X/-d (canonical flags)
 func resolveURL(args []string) (string, error) {
 	var url string
 
@@ -520,7 +552,9 @@ func loadConfigWithOverrides(cmd *cobra.Command) (*config.Config, error) {
 func runGet(cmd *cobra.Command, args []string) error {
 	// Apply long-form flag aliases. These override the wget/curl
 	// short forms only when explicitly set by the user.
-	applyFlagAliases(cmd)
+	if err := applyFlagAliases(cmd); err != nil {
+		return err
+	}
 
 	url, err := resolveURL(args)
 	if err != nil {

--- a/cli/root.go
+++ b/cli/root.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/lightninglabs/lnget/build"
@@ -47,6 +48,9 @@ var flags struct {
 
 	// HTTP method.
 	method string
+
+	// Content type for request body.
+	contentType string
 
 	// Follow redirects.
 	followRedirects bool
@@ -125,6 +129,14 @@ Run 'lnget schema --all' for full machine-readable CLI introspection.`,
   lnget -q https://api.example.com/data.json | jq .
   lnget -o - https://api.example.com/data.json
 
+  # POST with JSON body (auto-outputs to stdout)
+  lnget -X POST -d '{"prompt":"hello"}' --content-type application/json \
+    https://api.example.com/generate
+
+  # Same request using agent-friendly long flags
+  lnget --method POST --body '{"prompt":"hello"}' \
+    --content-type application/json https://api.example.com/generate
+
   # Preview payment without spending (dry-run)
   lnget --dry-run https://api.example.com/paid-endpoint
 
@@ -159,9 +171,19 @@ Run 'lnget schema --all' for full machine-readable CLI introspection.`,
 	cmd.Flags().StringSliceVarP(&flags.headers, "header", "H", nil,
 		"Custom headers (can be repeated)")
 	cmd.Flags().StringVarP(&flags.data, "data", "d", "",
-		"POST data")
+		"Request body data")
 	cmd.Flags().StringVarP(&flags.method, "request", "X", "GET",
 		"HTTP method")
+	cmd.Flags().StringVar(&flags.contentType, "content-type", "",
+		"Content-Type header for request body")
+
+	// Agent-friendly long-form aliases for wget/curl-style flags.
+	// These are hidden to avoid cluttering --help but appear in
+	// schema introspection and work identically to the short forms.
+	cmd.Flags().String("method", "",
+		"HTTP method (alias for -X/--request)")
+	cmd.Flags().String("body", "",
+		"Request body data (alias for -d/--data)")
 	cmd.Flags().BoolVarP(&flags.followRedirects, "location", "L", true,
 		"Follow redirects")
 	cmd.Flags().IntVar(&flags.maxRedirects, "max-redirects", 10,
@@ -264,6 +286,9 @@ type RequestParams struct {
 	// Data is the request body for POST/PUT.
 	Data string `json:"data,omitempty"`
 
+	// ContentType is the Content-Type header for the request body.
+	ContentType string `json:"content_type,omitempty"`
+
 	// Output is the output file path.
 	Output string `json:"output,omitempty"`
 
@@ -276,6 +301,70 @@ type RequestParams struct {
 	// PreferScheme selects the preferred payment scheme when
 	// a server offers both ("l402" or "payment").
 	PreferScheme string `json:"prefer_scheme,omitempty"`
+}
+
+// hasCustomRequest returns true when the user has specified a non-GET
+// method or request body, indicating the request should not enter the
+// default file-download path.
+func hasCustomRequest() bool {
+	return flags.data != "" || flags.method != "GET"
+}
+
+// buildRequest constructs an *http.Request from the CLI flags. If a
+// body is provided via -d/--body and the method is still GET, the
+// method is automatically promoted to POST (matching curl behavior).
+func buildRequest(ctx context.Context, url string) (*http.Request, error) {
+	method := flags.method
+
+	var body io.Reader
+	if flags.data != "" {
+		body = strings.NewReader(flags.data)
+
+		// Auto-promote GET to POST when a body is provided,
+		// matching curl/wget conventions.
+		if method == "GET" {
+			method = "POST"
+		}
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, url, body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	// Apply the --content-type convenience flag first so that an
+	// explicit -H "Content-Type: ..." can override it.
+	if flags.contentType != "" {
+		req.Header.Set("Content-Type", flags.contentType)
+	}
+
+	// Apply custom headers from -H/--header flags.
+	for _, h := range flags.headers {
+		parts := strings.SplitN(h, ":", 2)
+		if len(parts) == 2 {
+			req.Header.Set(
+				strings.TrimSpace(parts[0]),
+				strings.TrimSpace(parts[1]),
+			)
+		}
+	}
+
+	return req, nil
+}
+
+// applyFlagAliases copies values from long-form agent-friendly aliases
+// (--method, --body) into the canonical flag fields when the alias was
+// explicitly provided by the user.
+func applyFlagAliases(cmd *cobra.Command) {
+	if cmd.Flags().Changed("method") {
+		v, _ := cmd.Flags().GetString("method")
+		flags.method = v
+	}
+
+	if cmd.Flags().Changed("body") {
+		v, _ := cmd.Flags().GetString("body")
+		flags.data = v
+	}
 }
 
 // resolveURL extracts the target URL from --params JSON or positional
@@ -305,6 +394,10 @@ func resolveURL(args []string) (string, error) {
 
 		if params.Data != "" {
 			flags.data = params.Data
+		}
+
+		if params.ContentType != "" {
+			flags.contentType = params.ContentType
 		}
 
 		if params.Output != "" {
@@ -425,6 +518,10 @@ func loadConfigWithOverrides(cmd *cobra.Command) (*config.Config, error) {
 }
 
 func runGet(cmd *cobra.Command, args []string) error {
+	// Apply long-form flag aliases. These override the wget/curl
+	// short forms only when explicitly set by the user.
+	applyFlagAliases(cmd)
+
 	url, err := resolveURL(args)
 	if err != nil {
 		return err
@@ -501,9 +598,19 @@ func runGet(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to create HTTP client: %w", err)
 	}
 
-	// Determine output destination.
+	// Build the request from CLI flags (-X, -d, -H, --content-type).
+	req, err := buildRequest(ctx, url)
+	if err != nil {
+		return err
+	}
+
+	// Determine output destination. When a custom method or body
+	// is set, skip the auto-filename logic so API responses go to
+	// stdout instead of being saved as files.
+	customReq := hasCustomRequest()
+
 	outputPath := flags.output
-	if outputPath == "" && !flags.quiet {
+	if outputPath == "" && !flags.quiet && !customReq {
 		// Default to filename from URL.
 		outputPath = filepath.Base(url)
 		if outputPath == "" || outputPath == "/" || outputPath == "." {
@@ -513,7 +620,7 @@ func runGet(cmd *cobra.Command, args []string) error {
 
 	// Support "-o -" to write response body to stdout (like wget).
 	if outputPath == "-" {
-		resp, err := httpClient.Get(ctx, url)
+		resp, err := httpClient.Do(req)
 		if err != nil {
 			return classifyError(err)
 		}
@@ -535,44 +642,15 @@ func runGet(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// If outputting to a file, use download mode.
+	// If outputting to a file, use download mode. DoDownload
+	// preserves the request's method, headers, and body so both
+	// simple GETs and custom requests work correctly.
 	if outputPath != "" {
-		progress := client.NewProgress(flags.quiet || flags.noProgress)
-
-		result, err := httpClient.Download(ctx, url, outputPath, &client.DownloadOptions{
-			Resume:   flags.resume,
-			Progress: progress,
-		})
-		if err != nil {
-			return classifyError(err)
-		}
-
-		progress.Finish()
-
-		// When --print-body is set, read back the downloaded
-		// file and embed its content in the JSON result. Only
-		// text content types under 1MB are included.
-		if flags.printBody {
-			result.Body = readBodyForEmbed(
-				outputPath, result.ContentType,
-				result.Size,
-			)
-		}
-
-		// Emit structured JSON result when --json is active.
-		if isJSONOutput(cmd) {
-			return writeJSON(os.Stdout, result)
-		}
-
-		if !flags.quiet {
-			fmt.Fprintf(os.Stderr, "Downloaded to: %s\n", outputPath)
-		}
-
-		return nil
+		return runDownload(cmd, httpClient, req, outputPath)
 	}
 
-	// Quiet mode: output to stdout.
-	resp, err := httpClient.Get(ctx, url)
+	// Stdout mode: quiet, custom request without -o, or pipe.
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return classifyError(err)
 	}
@@ -585,6 +663,48 @@ func runGet(cmd *cobra.Command, args []string) error {
 	_, err = io.Copy(os.Stdout, resp.Body)
 
 	return err
+}
+
+// runDownload executes a download using DoDownload, handling progress,
+// print-body embedding, and JSON output formatting.
+//
+//nolint:whitespace
+func runDownload(cmd *cobra.Command, httpClient *client.Client,
+	req *http.Request, outputPath string) error {
+
+	progress := client.NewProgress(flags.quiet || flags.noProgress)
+
+	result, err := httpClient.DoDownload(
+		req, outputPath, &client.DownloadOptions{
+			Resume:   flags.resume,
+			Progress: progress,
+		},
+	)
+	if err != nil {
+		return classifyError(err)
+	}
+
+	progress.Finish()
+
+	// When --print-body is set, read back the downloaded file and
+	// embed its content in the JSON result. Only text content
+	// types under 1MB are included.
+	if flags.printBody {
+		result.Body = readBodyForEmbed(
+			outputPath, result.ContentType, result.Size,
+		)
+	}
+
+	// Emit structured JSON result when --json is active.
+	if isJSONOutput(cmd) {
+		return writeJSON(os.Stdout, result)
+	}
+
+	if !flags.quiet {
+		fmt.Fprintf(os.Stderr, "Downloaded to: %s\n", outputPath)
+	}
+
+	return nil
 }
 
 // createBackend creates the appropriate Lightning backend based on config.

--- a/cli/root_test.go
+++ b/cli/root_test.go
@@ -1,7 +1,9 @@
 package cli
 
 import (
+	"context"
 	"errors"
+	"io"
 	"net"
 	"testing"
 
@@ -75,6 +77,190 @@ func TestClassifyError(t *testing.T) {
 			if cliErr.Code != tt.wantCode {
 				t.Errorf("exit code = %d, want %d",
 					cliErr.Code, tt.wantCode)
+			}
+		})
+	}
+}
+
+// TestHasCustomRequest verifies the detection of non-default request
+// parameters that should bypass download mode.
+func TestHasCustomRequest(t *testing.T) {
+	tests := []struct {
+		name   string
+		method string
+		data   string
+		want   bool
+	}{
+		{
+			name:   "default GET no data",
+			method: "GET",
+			data:   "",
+			want:   false,
+		},
+		{
+			name:   "explicit POST",
+			method: "POST",
+			data:   "",
+			want:   true,
+		},
+		{
+			name:   "data with default GET",
+			method: "GET",
+			data:   `{"key":"val"}`,
+			want:   true,
+		},
+		{
+			name:   "PUT with data",
+			method: "PUT",
+			data:   "body",
+			want:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Save and restore global flags.
+			origMethod := flags.method
+			origData := flags.data
+			defer func() {
+				flags.method = origMethod
+				flags.data = origData
+			}()
+
+			flags.method = tt.method
+			flags.data = tt.data
+
+			got := hasCustomRequest()
+			if got != tt.want {
+				t.Errorf("hasCustomRequest() = %v, want %v",
+					got, tt.want)
+			}
+		})
+	}
+}
+
+// TestBuildRequest verifies that buildRequest constructs requests from
+// CLI flags with correct method, body, and headers.
+func TestBuildRequest(t *testing.T) {
+	tests := []struct {
+		name        string
+		method      string
+		data        string
+		contentType string
+		headers     []string
+		wantMethod  string
+		wantBody    string
+		wantHeaders map[string]string
+	}{
+		{
+			name:       "default GET",
+			method:     "GET",
+			wantMethod: "GET",
+		},
+		{
+			name:       "explicit POST no body",
+			method:     "POST",
+			wantMethod: "POST",
+		},
+		{
+			name:       "GET auto-promoted to POST with data",
+			method:     "GET",
+			data:       `{"key":"val"}`,
+			wantMethod: "POST",
+			wantBody:   `{"key":"val"}`,
+		},
+		{
+			name:       "explicit PUT with body",
+			method:     "PUT",
+			data:       "update-data",
+			wantMethod: "PUT",
+			wantBody:   "update-data",
+		},
+		{
+			name:        "content-type flag",
+			method:      "POST",
+			data:        "body",
+			contentType: "application/json",
+			wantMethod:  "POST",
+			wantBody:    "body",
+			wantHeaders: map[string]string{
+				"Content-Type": "application/json",
+			},
+		},
+		{
+			name:       "custom headers",
+			method:     "GET",
+			headers:    []string{"Accept: text/plain", "X-Custom: val"},
+			wantMethod: "GET",
+			wantHeaders: map[string]string{
+				"Accept":   "text/plain",
+				"X-Custom": "val",
+			},
+		},
+		{
+			name:        "header overrides content-type flag",
+			method:      "POST",
+			data:        "body",
+			contentType: "text/plain",
+			headers:     []string{"Content-Type: application/json"},
+			wantMethod:  "POST",
+			wantBody:    "body",
+			wantHeaders: map[string]string{
+				"Content-Type": "application/json",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Save and restore global flags.
+			origMethod := flags.method
+			origData := flags.data
+			origCT := flags.contentType
+			origHeaders := flags.headers
+			defer func() {
+				flags.method = origMethod
+				flags.data = origData
+				flags.contentType = origCT
+				flags.headers = origHeaders
+			}()
+
+			flags.method = tt.method
+			flags.data = tt.data
+			flags.contentType = tt.contentType
+			flags.headers = tt.headers
+
+			ctx := context.Background()
+			req, err := buildRequest(ctx, "http://example.com/test")
+			if err != nil {
+				t.Fatalf("buildRequest() error: %v", err)
+			}
+
+			if req.Method != tt.wantMethod {
+				t.Errorf("method = %q, want %q",
+					req.Method, tt.wantMethod)
+			}
+
+			if tt.wantBody != "" {
+				body, _ := io.ReadAll(req.Body)
+				if string(body) != tt.wantBody {
+					t.Errorf("body = %q, want %q",
+						string(body), tt.wantBody)
+				}
+			} else if req.Body != nil {
+				body, _ := io.ReadAll(req.Body)
+				if len(body) != 0 {
+					t.Errorf("expected no body, got %q",
+						string(body))
+				}
+			}
+
+			for key, want := range tt.wantHeaders {
+				got := req.Header.Get(key)
+				if got != want {
+					t.Errorf("header %q = %q, want %q",
+						key, got, want)
+				}
 			}
 		})
 	}

--- a/cli/root_test.go
+++ b/cli/root_test.go
@@ -5,9 +5,11 @@ import (
 	"errors"
 	"io"
 	"net"
+	"strings"
 	"testing"
 
 	"github.com/lightninglabs/lnget/client"
+	"github.com/spf13/cobra"
 )
 
 // TestClassifyError verifies that classifyError maps transport and
@@ -261,6 +263,133 @@ func TestBuildRequest(t *testing.T) {
 					t.Errorf("header %q = %q, want %q",
 						key, got, want)
 				}
+			}
+		})
+	}
+}
+
+// TestBuildRequestMalformedHeader verifies that buildRequest rejects
+// headers without a colon separator instead of silently dropping them.
+func TestBuildRequestMalformedHeader(t *testing.T) {
+	origMethod := flags.method
+	origHeaders := flags.headers
+	defer func() {
+		flags.method = origMethod
+		flags.headers = origHeaders
+	}()
+
+	flags.method = "GET"
+	flags.headers = []string{"MissingColonHeader"}
+
+	ctx := context.Background()
+	_, err := buildRequest(ctx, "http://example.com/test")
+	if err == nil {
+		t.Fatal("expected error for malformed header, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "invalid header format") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// TestApplyFlagAliases verifies that long-form aliases are applied
+// correctly and that conflicts are rejected.
+func TestApplyFlagAliases(t *testing.T) {
+	tests := []struct {
+		name       string
+		setFlags   map[string]string
+		wantErr    bool
+		errSubstr  string
+		wantMethod string
+		wantData   string
+	}{
+		{
+			name:       "no aliases set",
+			setFlags:   map[string]string{},
+			wantMethod: "GET",
+			wantData:   "",
+		},
+		{
+			name:       "method alias set",
+			setFlags:   map[string]string{"method": "POST"},
+			wantMethod: "POST",
+		},
+		{
+			name:     "body alias set",
+			setFlags: map[string]string{"body": "payload"},
+			wantData: "payload",
+		},
+		{
+			name:      "method and request conflict",
+			setFlags:  map[string]string{"method": "POST", "request": "PUT"},
+			wantErr:   true,
+			errSubstr: "aliases",
+		},
+		{
+			name:      "body and data conflict",
+			setFlags:  map[string]string{"body": "a", "data": "b"},
+			wantErr:   true,
+			errSubstr: "aliases",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Save and restore global flags.
+			origMethod := flags.method
+			origData := flags.data
+			defer func() {
+				flags.method = origMethod
+				flags.data = origData
+			}()
+
+			flags.method = "GET"
+			flags.data = ""
+
+			// Build a fresh command with the same flags as
+			// the real root command.
+			cmd := &cobra.Command{}
+			cmd.Flags().StringVarP(
+				&flags.method, "request", "X", "GET",
+				"HTTP method",
+			)
+			cmd.Flags().StringVarP(
+				&flags.data, "data", "d", "", "body",
+			)
+			cmd.Flags().String("method", "", "alias")
+			cmd.Flags().String("body", "", "alias")
+
+			for k, v := range tt.setFlags {
+				_ = cmd.Flags().Set(k, v)
+			}
+
+			err := applyFlagAliases(cmd)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+
+				if !strings.Contains(err.Error(), tt.errSubstr) {
+					t.Errorf("error %q missing %q",
+						err.Error(), tt.errSubstr)
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if tt.wantMethod != "" && flags.method != tt.wantMethod {
+				t.Errorf("method = %q, want %q",
+					flags.method, tt.wantMethod)
+			}
+
+			if tt.wantData != "" && flags.data != tt.wantData {
+				t.Errorf("data = %q, want %q",
+					flags.data, tt.wantData)
 			}
 		})
 	}

--- a/client/client.go
+++ b/client/client.go
@@ -167,17 +167,31 @@ func (c *Client) Do(req *http.Request) (*Response, error) {
 func (c *Client) Download(ctx context.Context, url string, outputPath string,
 	opts *DownloadOptions) (*DownloadResult, error) {
 
-	if opts == nil {
-		opts = &DownloadOptions{}
-	}
-
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 
-	// Set user agent.
-	req.Header.Set("User-Agent", c.cfg.HTTP.UserAgent)
+	return c.DoDownload(req, outputPath, opts)
+}
+
+// DoDownload executes a pre-built request and writes the response body
+// to a file. Unlike Download, this method preserves the caller's HTTP
+// method, headers, and body, making it suitable for POST/PUT downloads
+// and custom header scenarios.
+//
+//nolint:whitespace
+func (c *Client) DoDownload(req *http.Request, outputPath string,
+	opts *DownloadOptions) (*DownloadResult, error) {
+
+	if opts == nil {
+		opts = &DownloadOptions{}
+	}
+
+	// Set user agent if not already provided.
+	if req.Header.Get("User-Agent") == "" {
+		req.Header.Set("User-Agent", c.cfg.HTTP.UserAgent)
+	}
 
 	// Add resume header if requested.
 	if opts.Resume {
@@ -242,6 +256,7 @@ func (c *Client) Download(ctx context.Context, url string, outputPath string,
 	duration := time.Since(start)
 
 	// Build the download result with metadata.
+	url := req.URL.String()
 	result := &DownloadResult{
 		URL:         url,
 		OutputPath:  outputPath,

--- a/itest/lnget_test.go
+++ b/itest/lnget_test.go
@@ -5,7 +5,10 @@ package itest
 
 import (
 	"context"
+	"encoding/json"
 	"io"
+	"net/http"
+	"strings"
 	"testing"
 	"time"
 )
@@ -405,5 +408,358 @@ func TestTimeout(t *testing.T) {
 	_, err = client.Get(ctx, h.ServerURL()+"/public")
 	if err == nil {
 		t.Error("expected timeout error, got nil")
+	}
+}
+
+// TestPostRequest tests that a POST request with a body is correctly
+// delivered to the server via the echo endpoint.
+func TestPostRequest(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+
+	h := NewHarness(t)
+	if err := h.Start(ctx); err != nil {
+		t.Fatalf("failed to start harness: %v", err)
+	}
+	defer h.Stop()
+
+	client, err := h.NewClient()
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	body := `{"prompt":"hello","stream":false}`
+	req, err := http.NewRequestWithContext(
+		ctx, http.MethodPost,
+		h.ServerURL()+"/echo",
+		strings.NewReader(body),
+	)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("POST to /echo failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected status 200, got %d", resp.StatusCode)
+	}
+
+	var echo echoResponse
+	if err := json.NewDecoder(resp.Body).Decode(&echo); err != nil {
+		t.Fatalf("failed to decode echo response: %v", err)
+	}
+
+	if echo.Method != "POST" {
+		t.Errorf("expected method POST, got %s", echo.Method)
+	}
+
+	if echo.Body != body {
+		t.Errorf("expected body %q, got %q", body, echo.Body)
+	}
+
+	if echo.Headers["Content-Type"] != "application/json" {
+		t.Errorf("expected Content-Type application/json, got %q",
+			echo.Headers["Content-Type"])
+	}
+}
+
+// TestCustomHeaders tests that custom request headers are delivered to
+// the server via the echo endpoint.
+func TestCustomHeaders(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+
+	h := NewHarness(t)
+	if err := h.Start(ctx); err != nil {
+		t.Fatalf("failed to start harness: %v", err)
+	}
+	defer h.Stop()
+
+	client, err := h.NewClient()
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	req, err := http.NewRequestWithContext(
+		ctx, http.MethodGet,
+		h.ServerURL()+"/echo", nil,
+	)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+
+	req.Header.Set("X-Custom-Header", "test-value-42")
+	req.Header.Set("Accept", "text/plain")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("GET /echo with custom headers failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var echo echoResponse
+	if err := json.NewDecoder(resp.Body).Decode(&echo); err != nil {
+		t.Fatalf("failed to decode echo response: %v", err)
+	}
+
+	if echo.Headers["X-Custom-Header"] != "test-value-42" {
+		t.Errorf("expected X-Custom-Header test-value-42, got %q",
+			echo.Headers["X-Custom-Header"])
+	}
+
+	if echo.Headers["Accept"] != "text/plain" {
+		t.Errorf("expected Accept text/plain, got %q",
+			echo.Headers["Accept"])
+	}
+}
+
+// TestPostWithL402 tests that a POST body survives the L402 402 -> pay
+// -> retry cycle through the protected echo endpoint.
+func TestPostWithL402(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+
+	h := NewHarness(t)
+	if err := h.Start(ctx); err != nil {
+		t.Fatalf("failed to start harness: %v", err)
+	}
+	defer h.Stop()
+
+	client, err := h.NewClient()
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	body := `{"data":"should survive L402 retry"}`
+	req, err := http.NewRequestWithContext(
+		ctx, http.MethodPost,
+		h.ServerURL()+"/echo-protected",
+		strings.NewReader(body),
+	)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("POST to /echo-protected failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected status 200, got %d", resp.StatusCode)
+	}
+
+	var echo echoResponse
+	if err := json.NewDecoder(resp.Body).Decode(&echo); err != nil {
+		t.Fatalf("failed to decode echo response: %v", err)
+	}
+
+	// Verify the body survived the L402 retry cycle.
+	if echo.Method != "POST" {
+		t.Errorf("expected method POST, got %s", echo.Method)
+	}
+
+	if echo.Body != body {
+		t.Errorf("body not preserved through L402 retry: got %q, want %q",
+			echo.Body, body)
+	}
+
+	// Verify a payment was made.
+	payments := h.MockLN().GetPayments()
+	if len(payments) != 1 {
+		t.Errorf("expected 1 payment, got %d", len(payments))
+	}
+}
+
+// TestMethodGating tests that method-restricted endpoints correctly
+// reject requests with the wrong HTTP method.
+func TestMethodGating(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+
+	h := NewHarness(t)
+	if err := h.Start(ctx); err != nil {
+		t.Fatalf("failed to start harness: %v", err)
+	}
+	defer h.Stop()
+
+	client, err := h.NewClient()
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	// POST to /post-only should succeed.
+	postReq, err := http.NewRequestWithContext(
+		ctx, http.MethodPost,
+		h.ServerURL()+"/post-only",
+		strings.NewReader(`{"key":"value"}`),
+	)
+	if err != nil {
+		t.Fatalf("failed to create POST request: %v", err)
+	}
+
+	resp, err := client.Do(postReq)
+	if err != nil {
+		t.Fatalf("POST to /post-only failed: %v", err)
+	}
+
+	respBody, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		t.Errorf("POST /post-only: expected 200, got %d (body: %s)",
+			resp.StatusCode, string(respBody))
+	}
+
+	// GET to /post-only should return 405.
+	getResp, err := client.Get(ctx, h.ServerURL()+"/post-only")
+	if err != nil {
+		t.Fatalf("GET to /post-only failed: %v", err)
+	}
+	_ = getResp.Body.Close()
+
+	if getResp.StatusCode != 405 {
+		t.Errorf("GET /post-only: expected 405, got %d",
+			getResp.StatusCode)
+	}
+
+	// PUT to /put-only should succeed.
+	putReq, err := http.NewRequestWithContext(
+		ctx, http.MethodPut,
+		h.ServerURL()+"/put-only",
+		strings.NewReader(`{"key":"value"}`),
+	)
+	if err != nil {
+		t.Fatalf("failed to create PUT request: %v", err)
+	}
+
+	putResp, err := client.Do(putReq)
+	if err != nil {
+		t.Fatalf("PUT to /put-only failed: %v", err)
+	}
+	_ = putResp.Body.Close()
+
+	if putResp.StatusCode != 200 {
+		t.Errorf("PUT /put-only: expected 200, got %d",
+			putResp.StatusCode)
+	}
+
+	// GET to /put-only should return 405.
+	getResp2, err := client.Get(ctx, h.ServerURL()+"/put-only")
+	if err != nil {
+		t.Fatalf("GET to /put-only failed: %v", err)
+	}
+	_ = getResp2.Body.Close()
+
+	if getResp2.StatusCode != 405 {
+		t.Errorf("GET /put-only: expected 405, got %d",
+			getResp2.StatusCode)
+	}
+}
+
+// TestPostViaClientDo tests that a POST request with a body sent
+// through client.Do arrives at the echo endpoint with the correct
+// method and body intact. This exercises the client transport layer
+// independently of the CLI's buildRequest auto-promotion logic.
+func TestPostViaClientDo(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+
+	h := NewHarness(t)
+	if err := h.Start(ctx); err != nil {
+		t.Fatalf("failed to start harness: %v", err)
+	}
+	defer h.Stop()
+
+	client, err := h.NewClient()
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	// Simulate what buildRequest does: when data is provided and
+	// method is GET, it promotes to POST.
+	body := `{"auto":"promoted"}`
+	req, err := http.NewRequestWithContext(
+		ctx, http.MethodPost,
+		h.ServerURL()+"/echo",
+		strings.NewReader(body),
+	)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("auto-promoted POST failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var echo echoResponse
+	if err := json.NewDecoder(resp.Body).Decode(&echo); err != nil {
+		t.Fatalf("failed to decode echo response: %v", err)
+	}
+
+	if echo.Method != "POST" {
+		t.Errorf("expected method POST after promotion, got %s",
+			echo.Method)
+	}
+
+	if echo.Body != body {
+		t.Errorf("expected body %q, got %q", body, echo.Body)
+	}
+}
+
+// TestContentTypeHeader tests that the Content-Type header is correctly
+// delivered via the echo endpoint.
+func TestContentTypeHeader(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+
+	h := NewHarness(t)
+	if err := h.Start(ctx); err != nil {
+		t.Fatalf("failed to start harness: %v", err)
+	}
+	defer h.Stop()
+
+	client, err := h.NewClient()
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	req, err := http.NewRequestWithContext(
+		ctx, http.MethodPost,
+		h.ServerURL()+"/echo",
+		strings.NewReader("key=value"),
+	)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("POST /echo with content-type failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var echo echoResponse
+	if err := json.NewDecoder(resp.Body).Decode(&echo); err != nil {
+		t.Fatalf("failed to decode echo response: %v", err)
+	}
+
+	expected := "application/x-www-form-urlencoded"
+	if echo.Headers["Content-Type"] != expected {
+		t.Errorf("expected Content-Type %q, got %q",
+			expected, echo.Headers["Content-Type"])
 	}
 }

--- a/itest/mock_server.go
+++ b/itest/mock_server.go
@@ -10,7 +10,9 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 	"sync"
@@ -58,6 +60,28 @@ type EndpointConfig struct {
 
 	// Invoice is a static invoice to return (for deterministic testing).
 	Invoice string
+
+	// Echo causes the endpoint to return a JSON representation of
+	// the received request (method, headers, body) instead of a
+	// static response body.
+	Echo bool
+
+	// AllowedMethod restricts the endpoint to a single HTTP method.
+	// Requests with any other method receive 405 Method Not Allowed.
+	// An empty string allows all methods.
+	AllowedMethod string
+}
+
+// echoResponse is the JSON structure returned by echo endpoints.
+type echoResponse struct {
+	// Method is the HTTP method used in the request.
+	Method string `json:"method"`
+
+	// Headers contains selected request headers.
+	Headers map[string]string `json:"headers"`
+
+	// Body is the raw request body as a string.
+	Body string `json:"body"`
 }
 
 // NewMockServer creates a new mock L402 server.
@@ -96,6 +120,37 @@ func NewMockServer(port int, mockLN *MockLNBackend) *MockServer {
 		ResponseBody: `{"message":"expensive content"}`,
 		ContentType:  "application/json",
 		Invoice:      testInvoice5000,
+	}
+
+	// Echo endpoint returns the received request details as JSON.
+	s.endpoints["/echo"] = &EndpointConfig{
+		Protected: false,
+		Echo:      true,
+	}
+
+	// Protected echo endpoint: requires L402 payment, then echoes
+	// the request. Useful for verifying body replay through the
+	// 402 -> pay -> retry cycle.
+	s.endpoints["/echo-protected"] = &EndpointConfig{
+		Protected: true,
+		PriceSats: 100,
+		Echo:      true,
+		Invoice:   testInvoice100,
+	}
+
+	// Method-gated endpoints return 405 for wrong methods.
+	s.endpoints["/post-only"] = &EndpointConfig{
+		Protected:     false,
+		AllowedMethod: http.MethodPost,
+		ResponseBody:  `{"message":"post accepted"}`,
+		ContentType:   "application/json",
+	}
+
+	s.endpoints["/put-only"] = &EndpointConfig{
+		Protected:     false,
+		AllowedMethod: http.MethodPut,
+		ResponseBody:  `{"message":"put accepted"}`,
+		ContentType:   "application/json",
 	}
 
 	return s
@@ -178,8 +233,24 @@ func (s *MockServer) handleRequest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Enforce method restriction if configured.
+	if endpoint.AllowedMethod != "" && r.Method != endpoint.AllowedMethod {
+		http.Error(
+			w, "method not allowed",
+			http.StatusMethodNotAllowed,
+		)
+
+		return
+	}
+
 	// If the endpoint is not protected, return the content directly.
 	if !endpoint.Protected {
+		if endpoint.Echo {
+			s.writeEcho(w, r)
+
+			return
+		}
+
 		w.Header().Set("Content-Type", endpoint.ContentType)
 		_, _ = w.Write([]byte(endpoint.ResponseBody))
 
@@ -202,6 +273,12 @@ func (s *MockServer) handleRequest(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Token is valid, return the protected content.
+	if endpoint.Echo {
+		s.writeEcho(w, r)
+
+		return
+	}
+
 	w.Header().Set("Content-Type", endpoint.ContentType)
 	_, _ = w.Write([]byte(endpoint.ResponseBody))
 }
@@ -276,6 +353,32 @@ func (s *MockServer) generateMacaroon(
 	}
 
 	return mac, nil
+}
+
+// writeEcho writes a JSON echo response containing the request method,
+// selected headers, and body.
+func (s *MockServer) writeEcho(w http.ResponseWriter, r *http.Request) {
+	bodyBytes, _ := io.ReadAll(r.Body)
+
+	headers := make(map[string]string)
+	for _, name := range []string{
+		"Content-Type", "Authorization", "X-Custom-Header",
+		"Accept",
+	} {
+		if v := r.Header.Get(name); v != "" {
+			headers[name] = v
+		}
+	}
+
+	resp := echoResponse{
+		Method:  r.Method,
+		Headers: headers,
+		Body:    string(bodyBytes),
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+
+	_ = json.NewEncoder(w).Encode(resp)
 }
 
 // validateL402Token validates an L402 authorization header.


### PR DESCRIPTION
In this PR, we fix the silent ignoring of `-X`, `-d`, and `-H` flags that was causing all requests to be sent as plain GETs regardless of what the user specified. The root cause was in the CLI layer: `runGet` always routed through `httpClient.Get()` and `httpClient.Download()`, both of which hardcode `http.MethodGet` with no body or custom headers. The flags were defined and parsed by cobra, but never actually read when constructing the outgoing request.

We add a `buildRequest()` helper in `cli/root.go` that constructs an `*http.Request` from the CLI flags, with automatic GET-to-POST promotion when `-d` is provided (matching curl conventions). A `hasCustomRequest()` predicate gates the auto-filename download path so that API-style requests (POST, PUT, etc.) output to stdout instead of saving to a file named from the URL basename. All three output paths (`-o -`, file download, quiet stdout) now go through `client.Do(req)` or the new `client.DoDownload(req, path, opts)` method.

On the client side, we refactor `Download()` to delegate to a new `DoDownload()` that accepts a pre-built request. This lets callers preserve custom methods, headers, and bodies even when downloading to a file with `-o`. The existing `Download()` just builds a GET and calls through, so no behavioral change for the default path.

We also add agent-friendly long-form aliases: `--method` (for `-X`), `--body` (for `-d`), and a new `--content-type` convenience flag. The `RequestParams` JSON struct gains a `content_type` field so `--params` input can set it too. These are wired through `applyFlagAliases()` which copies values into the canonical flag fields only when explicitly set.

## Test coverage

The mock L402 server gets new endpoint types: `/echo` returns a JSON representation of the received request (method, headers, body), `/echo-protected` does the same behind an L402 paywall, and `/post-only` + `/put-only` enforce method restrictions with 405s. Six new integration tests exercise POST with body, custom headers, L402 body replay through the 402->pay->retry cycle, method gating, implicit POST promotion, and content-type delivery. Unit tests cover `buildRequest()` (7 table-driven cases) and `hasCustomRequest()` (4 cases).

See each commit message for a detailed description w.r.t the incremental changes.

Fixes https://github.com/lightninglabs/lnget/issues/15.