### PR TITLE
docs: Fix broken go install instructions (replace directive)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,17 +30,17 @@ lnget https://api.example.com/data/2
 
 ## Installation
 
-```bash
-go install github.com/lightninglabs/lnget/cmd/lnget@latest
-```
-
-Or build from source:
+Build from source:
 
 ```bash
 git clone https://github.com/lightninglabs/lnget.git
 cd lnget
 make install
 ```
+
+Note: `go install github.com/lightninglabs/lnget/cmd/lnget@latest` currently
+fails because `go.mod` contains `replace` directives, which `go install`
+does not honor for remote installs. Building from a clone works around this.
 
 ## Configuration
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -264,8 +264,15 @@ jobs:
   fetch:
     runs-on: ubuntu-latest
     steps:
-      - name: Install lnget
-        run: go install github.com/lightninglabs/lnget/cmd/lnget@latest
+      - name: Checkout lnget
+        uses: actions/checkout@v4
+        with:
+          repository: lightninglabs/lnget
+          path: lnget
+      - name: Build lnget
+        run: |
+          cd lnget
+          go build -o /usr/local/bin/lnget ./cmd/lnget
 
       - name: Configure lnget
         run: |
@@ -291,7 +298,10 @@ jobs:
 
 ```dockerfile
 FROM golang:1.22-alpine AS builder
-RUN go install github.com/lightninglabs/lnget/cmd/lnget@latest
+WORKDIR /src
+RUN apk add --no-cache git
+RUN git clone https://github.com/lightninglabs/lnget.git .
+RUN go build -o /go/bin/lnget ./cmd/lnget
 
 FROM alpine:latest
 COPY --from=builder /go/bin/lnget /usr/local/bin/

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -269,6 +269,10 @@ jobs:
         with:
           repository: lightninglabs/lnget
           path: lnget
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: lnget/go.mod
       - name: Build lnget
         run: |
           cd lnget
@@ -297,7 +301,7 @@ jobs:
 ### Docker usage
 
 ```dockerfile
-FROM golang:1.22-alpine AS builder
+FROM golang:1.25-alpine AS builder
 WORKDIR /src
 RUN apk add --no-cache git
 RUN git clone https://github.com/lightninglabs/lnget.git .

--- a/skills/lnget/SKILL.md
+++ b/skills/lnget/SKILL.md
@@ -34,12 +34,13 @@ additional payments.
 ## Installation
 
 ```bash
-# From source
-go install github.com/lightninglabs/lnget/cmd/lnget@latest
-
-# Or build locally
+# Build locally
 make install
 ```
+
+Note: `go install github.com/lightninglabs/lnget/cmd/lnget@latest` currently
+fails because `go.mod` contains `replace` directives, which `go install`
+does not honor for remote installs. Building from a clone works around this.
 
 ## Quick Reference
 


### PR DESCRIPTION
`go install github.com/lightninglabs/lnget/cmd/lnget@latest` fails on a clean machine:
```
go: github.com/lightninglabs/lnget/cmd/lnget@latest (in github.com/lightninglabs/lnget@v1.1.0):
        The go.mod file for the module providing named packages contains one or
        more replace directives. It must not contain directives that would cause
        it to be interpreted differently than if it were the main module.
```
(`go version go1.25.6 darwin/arm64`, macOS/Linux)

**Root cause**: `go.mod` contains:
```
replace google.golang.org/protobuf => github.com/lightninglabs/protobuf-go-hex-display v1.33.0-hex-display
```
which its own comment notes is required for `lnd v0.20.0-beta`'s custom protobuf (`UseHexForBytes`) — a real dependency, not something to remove. `go install pkg@version` doesn't honor `replace` directives for remote installs, so this can't work as currently documented. I didn't touch `go.mod` since the replace looks intentional and necessary; happy to help if there's a preferred way to surface this, but kept this PR scoped to docs.

**Fix**: updated all four places I found this instruction to build from a local clone instead, which I verified works.

**Testing**: this is a docs-only change — no `.go` files touched, so `make tidy-module-check` / `make unit` / `make lint` produce no different output. I did verify the new instructions themselves work on a clean clone.

While testing, I also found the Dockerfile's `golang:1.22-alpine` base predates `go.mod`'s current `go >= 1.25.0` requirement — bumped to `golang:1.25-alpine`. Since this is the kind of thing that goes stale again as `go.mod` changes, I also added an explicit `actions/setup-go` step (reading the version from `go.mod`) to the GitHub Actions example, which previously had no version pin and was relying on the runner's default.

One observation, not part of this PR: the broken instruction was duplicated across all three files, which suggests drift risk if it needs to change again, it might be worth a single canonical install snippet the others reference. Happy to take a pass at that separately if useful.

I hit this while building an L402 demo against this tool: [https://github.com/jgmcalpine/headless-records-l402-demo], happy to link it if useful context.